### PR TITLE
Add markdown-include, et al.

### DIFF
--- a/site-src/blog.html
+++ b/site-src/blog.html
@@ -1,4 +1,4 @@
-<bluesky-template name="_imports/main.html" />
+<bluesky-template path="_imports/main.html" />
 <bluesky-block name="content">
     <bluesky-markdown directory="blog" template="_imports/post.html" slot="content" sort="date" title="title"/>
 </bluesky-block>

--- a/site-src/blog.html
+++ b/site-src/blog.html
@@ -1,4 +1,4 @@
 <bluesky-template path="_imports/main.html" />
 <bluesky-block name="content">
-    <bluesky-markdown directory="blog" template="_imports/post.html" slot="content" sort="date" title="title"/>
+    <bluesky-markdown directory="blog" template="_imports/post.html" slot="content" sort="date" order="descending" title="title"/>
 </bluesky-block>

--- a/site-src/index.html
+++ b/site-src/index.html
@@ -1,4 +1,5 @@
 <bluesky-template path="_imports/main.html" />
 <bluesky-block name="content">
     <h1>Hello, world!</h1>
+    <bluesky-md-include path="test-include.md" />
 </bluesky-block>

--- a/site-src/index.html
+++ b/site-src/index.html
@@ -1,4 +1,4 @@
-<bluesky-template name="_imports/main.html" />
+<bluesky-template path="_imports/main.html" />
 <bluesky-block name="content">
     <h1>Hello, world!</h1>
 </bluesky-block>

--- a/site-src/test-include.md
+++ b/site-src/test-include.md
@@ -1,0 +1,17 @@
+---
+title: Test
+date: 2020-01-01
+desc: In which I test my parser
+---
+# Test
+This is a test
+
+```
+<bluesky-slot name="test">
+<bluesky-block name="test">
+  <div>
+    <h1>Test</h1>
+    <p>This is a test</p>
+  </div>
+</bluesky-block>
+```

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -43,9 +43,9 @@ void Block::render()
             }
             case Constants::IT_MD_INCLUDE:
             {
-                std::string name = utils::get_attribute(m_raw.substr(idx), "name");
+                std::string rel_path = utils::get_attribute(m_raw.substr(idx), "path");
                 size_t tag_end = m_raw.find(Constants::CLOSER, idx) + 1;
-                std::string path = utils::get_relative_path(m_path) + "/" + name;
+                std::string path = utils::get_relative_path(m_path) + "/" + rel_path;
                 auto content = utils::read_file(path);
                 ss << Markdown::parse(content);
                 last_idx = tag_end;

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -24,18 +24,10 @@ void Block::render()
     Constants::ImportType it;
     std::stringstream ss;
     size_t last_idx = 0;
-    bool code_fence = false;
     while ((idx = m_raw.find(Constants::OPENER, idx)) != std::string::npos)
     {
         it = utils::identify_import(m_raw, idx);
         ss << m_raw.substr(last_idx, idx - last_idx);
-        if (code_fence && it == Constants::IT_CODE)
-        {
-            last_idx = idx;
-            idx += 1;
-            code_fence = false;
-            continue;
-        }
         switch (it)
         {
             case Constants::IT_INCLUDE:
@@ -66,10 +58,6 @@ void Block::render()
                 Logger::warn("Unknown tag " + tag + ".");
                 last_idx = tag_end;
                 break;
-            }
-            case Constants::IT_CODE:
-            {
-                code_fence = true;
             }
             default:
             {

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -5,6 +5,7 @@
 #include "Block.h"
 #include "Constants.h"
 #include "Logger.h"
+#include "Markdown.h"
 #include "utils.h"
 
 #include <sstream>
@@ -45,6 +46,16 @@ void Block::render()
                 auto content = utils::read_file(path);
                 Block include(content, path);
                 ss << include.get_rendered();
+                last_idx = tag_end;
+                break;
+            }
+            case Constants::IT_MD_INCLUDE:
+            {
+                std::string name = utils::get_attribute(m_raw.substr(idx), "name");
+                size_t tag_end = m_raw.find(Constants::CLOSER, idx) + 1;
+                std::string path = utils::get_relative_path(m_path) + "/" + name;
+                auto content = utils::read_file(path);
+                ss << Markdown::parse(content);
                 last_idx = tag_end;
                 break;
             }

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -8,8 +8,8 @@
 #include "Markdown.h"
 #include "utils.h"
 
-#include <sstream>
 #include <iostream>
+#include <sstream>
 #include <utility>
 
 Block::Block(std::string raw, std::string path)

--- a/src/Block.h
+++ b/src/Block.h
@@ -6,7 +6,6 @@
 #define BLUESKY_BLOCK_H
 
 #include <string>
-#include "utils.h"
 
 
 class Block
@@ -23,9 +22,6 @@ public:
     Block(std::string raw, std::string path);
 
     ~Block() = default;
-
-    std::string get_raw()
-    { return m_raw; };
 
     std::string get_rendered()
     { return m_rendered; };

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -4,8 +4,9 @@
 
 #include "Config.h"
 #include "Logger.h"
-#include <unistd.h>
+
 #include <iostream>
+#include <unistd.h>
 
 // create a null instance of Config to be initialized by main
 Config *config = nullptr;

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -21,13 +21,14 @@ namespace Constants
         IT_BLOCK,
         IT_BLOCK_END,
         IT_UNKNOWN,
-        IT_CODE
+        IT_CODE,
+        IT_MD_INCLUDE
     };
     static const unsigned MD_FLAGS = MD_FLAG_COLLAPSEWHITESPACE | MD_FLAG_TABLES | MD_FLAG_TASKLISTS |
                                      MD_FLAG_STRIKETHROUGH | MD_FLAG_PERMISSIVEAUTOLINKS |
                                      MD_FLAG_PERMISSIVEWWWAUTOLINKS |
                                      MD_FLAG_LATEXMATHSPANS;
-    static const size_t IMPORT_TAG_LENGTH = 7;
+    static const size_t IMPORT_TAG_LENGTH = 8;
     static const std::string OPENER = "<bluesky-";
     static const std::string CLOSER = ">";
     static const std::string VARIABLE_OPENER = "${";
@@ -40,6 +41,7 @@ namespace Constants
             "<bluesky-block",
             "</bluesky-block>",
             "```",
+            "<bluesky-md-include"
     };
     static const std::string TEMPLATE_END = "</bluesky-template>";
     static const size_t DEFAULT_PORT = 8080;

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -5,9 +5,10 @@
 #ifndef BLUESKY_CONSTANTS_H
 #define BLUESKY_CONSTANTS_H
 
+#include "md4c.h"
+
 #include <string>
 #include <unordered_map>
-#include "md4c.h"
 
 namespace Constants
 {

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -21,14 +21,13 @@ namespace Constants
         IT_BLOCK,
         IT_BLOCK_END,
         IT_UNKNOWN,
-        IT_CODE,
         IT_MD_INCLUDE
     };
     static const unsigned MD_FLAGS = MD_FLAG_COLLAPSEWHITESPACE | MD_FLAG_TABLES | MD_FLAG_TASKLISTS |
                                      MD_FLAG_STRIKETHROUGH | MD_FLAG_PERMISSIVEAUTOLINKS |
                                      MD_FLAG_PERMISSIVEWWWAUTOLINKS |
                                      MD_FLAG_LATEXMATHSPANS;
-    static const size_t IMPORT_TAG_LENGTH = 8;
+    static const size_t IMPORT_TAG_LENGTH = 7;
     static const std::string OPENER = "<bluesky-";
     static const std::string CLOSER = ">";
     static const std::string VARIABLE_OPENER = "${";
@@ -40,7 +39,6 @@ namespace Constants
             "<bluesky-slot",
             "<bluesky-block",
             "</bluesky-block>",
-            "```",
             "<bluesky-md-include"
     };
     static const std::string TEMPLATE_END = "</bluesky-template>";

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -21,8 +21,8 @@ namespace Constants
         IT_SLOT,
         IT_BLOCK,
         IT_BLOCK_END,
+        IT_MD_INCLUDE,
         IT_UNKNOWN,
-        IT_MD_INCLUDE
     };
     static const unsigned MD_FLAGS = MD_FLAG_COLLAPSEWHITESPACE | MD_FLAG_TABLES | MD_FLAG_TASKLISTS |
                                      MD_FLAG_STRIKETHROUGH | MD_FLAG_PERMISSIVEAUTOLINKS |

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -2,8 +2,10 @@
 // Created by mas on 9/5/22.
 //
 
-#include "Logger.h"
 #include "Config.h"
+#include "Logger.h"
+
+#include <iostream>
 
 extern Config *config;
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -28,7 +28,7 @@ void Logger::warn(const std::string &msg)
 void Logger::error(const std::string &msg)
 {
     // make console red
-    fprintf(stderr, "\033[1;31mERROR: %s: %m\n", msg.c_str());
+    fprintf(stderr, "\033[1;31mERROR: %s: %m\n\033[0m", msg.c_str());
 }
 
 void Logger::info(const std::string &msg)

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -6,6 +6,7 @@
 #include "Logger.h"
 
 #include <iostream>
+#include <cerrno>
 
 extern Config *config;
 
@@ -27,7 +28,7 @@ void Logger::warn(const std::string &msg)
 void Logger::error(const std::string &msg)
 {
     // make console red
-    std::cerr << "\033[1;31m" << "ERROR: " << msg << "\033[0m" << std::endl ;
+    fprintf(stderr, "\033[1;31mERROR: %s: %m\n", msg.c_str());
 }
 
 void Logger::info(const std::string &msg)

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -4,7 +4,7 @@
 
 #ifndef BLUESKY_LOGGER_H
 #define BLUESKY_LOGGER_H
-#include <iostream>
+
 #include <string>
 
 class Logger{

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -2,11 +2,12 @@
 // Created by Michael Sendker on 9/1/22.
 //
 
-#include "Markdown.h"
 #include "Logger.h"
+#include "Markdown.h"
+
+#include <cstring>
 #include <iostream>
 #include <sstream>
-#include <cstring>
 
 /*
  * MD4C: Markdown parser for C

--- a/src/Meta.cpp
+++ b/src/Meta.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Meta.h"
+
 #include <fstream>
 #include <utility>
 

--- a/src/Meta.h
+++ b/src/Meta.h
@@ -5,8 +5,8 @@
 #ifndef BLUESKY_META_H
 #define BLUESKY_META_H
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 
 class Meta

--- a/src/Page.cpp
+++ b/src/Page.cpp
@@ -2,18 +2,18 @@
 // Created by mas on 7/4/22.
 //
 
-#include <fstream>
+#include "Block.h"
+#include "Config.h"
+#include "Markdown.h"
+#include "Meta.h"
+#include "Page.h"
+
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
-#include <sstream>
-
-#include "Page.h"
-#include "Config.h"
-#include "Block.h"
-#include "Meta.h"
-#include "Markdown.h"
 
 extern Config *config;
 extern Meta *meta;

--- a/src/Page.cpp
+++ b/src/Page.cpp
@@ -143,7 +143,7 @@ void Page::render_templating()
         return;
     }
     // instantiate template shared_ptr
-    std::string templ_path_raw = utils::get_attribute(tmp.substr(tmpl_idx), "template");
+    std::string templ_path_raw = utils::get_attribute(tmp.substr(tmpl_idx), "path");
     std::string templ_path = utils::get_relative_path(m_path) + "/" + templ_path_raw;
     Template template_obj(templ_path);
     std::shared_ptr<Template> template_ptr = std::make_shared<Template>(template_obj);

--- a/src/Page.cpp
+++ b/src/Page.cpp
@@ -19,14 +19,14 @@ extern Config *config;
 extern Meta *meta;
 
 Page::Page(std::string path)
-        : m_path(std::move(path)), m_lastmodified(0)
+        : m_path(std::move(path))
 {
     m_output_path = config->get_output_dir() + m_path.substr(config->get_input_dir().size());
     m_final_path = m_output_path.substr(config->get_output_dir().size());
 }
 
 Page::Page(std::string path, std::shared_ptr<Template> templ, std::string slot)
-        : m_path(std::move(path)), m_template(std::move(templ)), m_slot(std::move(slot)), m_lastmodified(0)
+        : m_path(std::move(path)), m_template(std::move(templ)), m_slot(std::move(slot))
 {
     std::string filepath = m_path.substr(config->get_input_dir().size());
     // replace .md with .html if it's a markdown file
@@ -54,7 +54,6 @@ Page::Page(const Page &page)
     m_slot = page.m_slot;
     m_children = page.m_children;
     m_frontmatter = page.m_frontmatter;
-    m_lastmodified = page.m_lastmodified;
 }
 
 // Destructor
@@ -202,7 +201,6 @@ void Page::render_variables()
 void Page::render()
 {
     m_raw = utils::read_file(m_path);
-    m_lastmodified = utils::get_last_modified(m_path);
     if (m_path.ends_with(".md"))
     {
         for (auto &pair: Markdown::parse_frontmatter(m_raw))

--- a/src/Page.h
+++ b/src/Page.h
@@ -5,18 +5,17 @@
 #ifndef BLUESKY_PAGE_H
 #define BLUESKY_PAGE_H
 
-#include <vector>
-#include <string>
-#include <memory>
 #include <iostream>
+#include <string>
 #include <sys/stat.h>
+#include <vector>
 
-#include "Constants.h"
-#include "Page.h"
 #include "Block.h"
+#include "Constants.h"
+#include "Logger.h"
+#include "Page.h"
 #include "Template.h"
 #include "utils.h"
-#include "Logger.h"
 
 
 class Page
@@ -55,9 +54,6 @@ public:
     void render();
 
     void write();
-
-    std::string get_out_path()
-    { return m_output_path; };
 
     std::string get_path()
     { return m_path; };

--- a/src/Page.h
+++ b/src/Page.h
@@ -29,7 +29,6 @@ private:
     std::string m_raw;
     std::string m_slot;
     std::string m_rendered;
-    time_t m_lastmodified;
 
     std::vector<Page> m_children;
     std::shared_ptr<Template> m_template;
@@ -69,9 +68,6 @@ public:
 
     std::string get_rendered() const
     { return m_rendered; };
-
-    time_t get_last_modified() const
-    { return m_lastmodified; };
 
 };
 

--- a/src/Page.h
+++ b/src/Page.h
@@ -6,6 +6,7 @@
 #define BLUESKY_PAGE_H
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <sys/stat.h>
 #include <vector>

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -2,9 +2,10 @@
 // Created by mas on 9/5/22.
 //
 
-#include "Server.h"
 #include "Constants.h"
 #include "Logger.h"
+#include "Server.h"
+
 #include <arpa/inet.h>
 #include <unistd.h>
 

--- a/src/Server.h
+++ b/src/Server.h
@@ -5,11 +5,12 @@
 #ifndef BLUESKY_SERVER_H
 #define BLUESKY_SERVER_H
 
-#include <unordered_map>
-#include <string>
+#include "Site.h"
+
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include "Site.h"
+#include <string>
+#include <unordered_map>
 
 
 class Server

--- a/src/Site.cpp
+++ b/src/Site.cpp
@@ -2,11 +2,12 @@
 // Created by mas on 7/4/22.
 //
 
-#include "Site.h"
-#include "Meta.h"
 #include "Config.h"
 #include "Logger.h"
+#include "Meta.h"
+#include "Site.h"
 #include "utils.h"
+
 #include <filesystem>
 #include <fstream>
 

--- a/src/Site.h
+++ b/src/Site.h
@@ -5,8 +5,9 @@
 #ifndef BLUESKY_SITE_H
 #define BLUESKY_SITE_H
 
-#include <vector>
 #include "Page.h"
+
+#include <vector>
 
 class Site
 {

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -7,8 +7,8 @@
 #include "Logger.h"
 #include "Template.h"
 #include "utils.h"
+
 #include <sstream>
-#include <iostream>
 
 extern Meta *meta;
 

--- a/src/Template.h
+++ b/src/Template.h
@@ -5,8 +5,8 @@
 #ifndef BLUESKY_TEMPLATE_H
 #define BLUESKY_TEMPLATE_H
 
-#include <vector>
 #include <string>
+#include <vector>
 #include <unordered_map>
 
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,13 +2,14 @@
 // Created by mas on 7/10/22.
 //
 
-#include "utils.h"
+#include "Config.h"
 #include "Logger.h"
+#include "utils.h"
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include "sys/stat.h"
-#include "Config.h"
+#include <sys/stat.h>
 
 extern Config *config;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -43,7 +43,7 @@ std::string utils::get_attribute(const std::string &line, const std::string &att
     size_t start = line.find(attribute);
     if (start == std::string::npos)
     {
-        Logger::warn("Warning: failed to find attribute " + attribute + " in " + line);
+        Logger::warn("failed to find attribute " + attribute + " in " + line);
         return "";
     }
     start += attribute.length();
@@ -57,7 +57,7 @@ std::string utils::read_file(const std::string &path)
     std::ifstream file(path);
     if (!file.is_open())
     {
-        Logger::warn("Error: failed to open file " + path);
+        Logger::error("failed to open file " + path);
         return "";
     }
     std::stringstream buffer;

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,7 @@
 #define BLUESKY_UTILS_H
 
 #include "Constants.h"
+
 #include <unordered_map>
 
 namespace utils


### PR DESCRIPTION
- Add <bluesky-md-include> tag for dropping a markdown file into a slot
- Clean up logger
- Clean up imports
- Remove unnecessary imports and variables
- Remove code fence blocking (which was useless)